### PR TITLE
Fixed unsafe timezone issue

### DIFF
--- a/LeLogger.php
+++ b/LeLogger.php
@@ -52,6 +52,8 @@ class LeLogger
 	private $_host_name = "";
 	private $_host_id = "";
 
+	private $host_timezone;
+
 	private $severity = LOG_DEBUG;
 
 	private $connectionTimeout;
@@ -70,12 +72,11 @@ class LeLogger
 
 	public static function getLogger($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled, $host_timezone)
 	{	
+		date_default_timezone_set($host_timezone);
 		if (!self::$m_instance)
 		{
-			self::$m_instance = new LeLogger($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled, $host_timezone);
+			self::$m_instance = new LeLogger($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled);
 		}
-
-		date_default_timezone_set($host_timezone);
 
 		return self::$m_instance;
 	}
@@ -88,7 +89,7 @@ class LeLogger
 		self::$m_instance = NULL;
 	}
 
-	private function __construct($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled, $host_timezone)
+	private function __construct($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled)
 	{
 
 		if ($datahubEnabled===true)
@@ -143,7 +144,6 @@ class LeLogger
 		{
 		$this->_host_id = "host_ID=".$host_id;
 		}		
-		
 		
 		$this->persistent = $persistent;
 

--- a/LeLogger.php
+++ b/LeLogger.php
@@ -88,7 +88,7 @@ class LeLogger
 		self::$m_instance = NULL;
 	}
 
-	private function __construct($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled)
+	private function __construct($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled, $host_timezone)
 	{
 
 		if ($datahubEnabled===true)

--- a/LeLogger.php
+++ b/LeLogger.php
@@ -60,6 +60,8 @@ class LeLogger
 
 	private $persistent = true;
 
+	private $default_host_timezone = "UTC";
+
 	private $use_ssl = false;
 	
 	private static $_timestampFormat = 'Y-m-d G:i:s';
@@ -70,7 +72,7 @@ class LeLogger
 	
 	private $errstr;
 
-	public static function getLogger($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled, $host_timezone)
+	public static function getLogger($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled, $host_timezone = self::$default_host_timezone)
 	{	
 		date_default_timezone_set($host_timezone);
 		if (!self::$m_instance)

--- a/LeLogger.php
+++ b/LeLogger.php
@@ -72,7 +72,7 @@ class LeLogger
 	{	
 		if (!self::$m_instance)
 		{
-			self::$m_instance = new LeLogger($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled);
+			self::$m_instance = new LeLogger($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled, $host_timezone);
 		}
 
 		date_default_timezone_set($host_timezone);

--- a/LeLogger.php
+++ b/LeLogger.php
@@ -17,6 +17,9 @@
 * @version 1.6
 */
 
+// Set the defaut system timezone
+date_default_timezone_set("UTC");
+
 class LeLogger 
 {
 	//BSD syslog log levels

--- a/LeLogger.php
+++ b/LeLogger.php
@@ -17,9 +17,6 @@
 * @version 1.6
 */
 
-// Set the defaut system timezone
-date_default_timezone_set("UTC");
-
 class LeLogger 
 {
 	//BSD syslog log levels
@@ -71,12 +68,14 @@ class LeLogger
 	
 	private $errstr;
 
-	public static function getLogger($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled)
+	public static function getLogger($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled, $host_timezone)
 	{	
 		if (!self::$m_instance)
 		{
 			self::$m_instance = new LeLogger($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled);
 		}
+
+		date_default_timezone_set($host_timezone);
 
 		return self::$m_instance;
 	}

--- a/LeLogger.php
+++ b/LeLogger.php
@@ -72,7 +72,7 @@ class LeLogger
 	
 	private $errstr;
 
-	public static function getLogger($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled, $host_timezone = self::$default_host_timezone)
+	public static function getLogger($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled, $host_timezone = "UTC")
 	{	
 		date_default_timezone_set($host_timezone);
 		if (!self::$m_instance)

--- a/logentries.php
+++ b/logentries.php
@@ -11,7 +11,8 @@
   	
   	$LOGENTRIES_TOKEN = "";
 
-
+  	// Set your app's timezone (default is UTC)
+  	$HOST_TIMEZONE = "UTC";
 
 /*  
 *	To Send Log Events To Your DataHub, Change The Following Variables
@@ -85,4 +86,4 @@
 	}
 	
 
-	$log = LeLogger::getLogger($LOGENTRIES_TOKEN, $Persistent, $SSL, $Severity, $DATAHUB_ENABLED, $DATAHUB_IP_ADDRESS, $DATAHUB_PORT, $HOST_ID, $HOST_NAME, $HOST_NAME_ENABLED);
+	$log = LeLogger::getLogger($LOGENTRIES_TOKEN, $Persistent, $SSL, $Severity, $DATAHUB_ENABLED, $DATAHUB_IP_ADDRESS, $DATAHUB_PORT, $HOST_ID, $HOST_NAME, $HOST_NAME_ENABLED, $HOST_TIMEZONE);


### PR DESCRIPTION
```
shane$ php logentries.php

Warning: date(): It is not safe to rely on the system's timezone settings. You are *required* to use the date.timezone setting or the date_default_timezone_set() function. In case you used any of those methods and you are still getting this warning, you most likely misspelled the timezone identifier. We selected the timezone 'UTC' for now, but please set date.timezone to select your timezone. in /Users/shane/le_php-master/LeLogger.php on line 404
```

Set the default timezone in the library to UTC

