### PR TITLE
Removing timestamp from log line items

### DIFF
--- a/LeLogger.php
+++ b/LeLogger.php
@@ -350,7 +350,7 @@ class LeLogger
 		$this->connectIfNotConnected();
 
 		if ($this->severity >= $curr_severity) {
-			$prefix = $this->_getTime($curr_severity);
+			$prefix = ''; // $this->_getTime($curr_severity);
 
 			$multiline = $this->substituteNewline($line);
 

--- a/LeLogger.php
+++ b/LeLogger.php
@@ -69,11 +69,11 @@ class LeLogger
 	
 	private $errstr;
 
-	public static function getLogger($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled)
 	{
+	public static function getLogger($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled, $add_local_timestamp)
 		if ( ! isset(self::$m_instance[$token]))
 		{
-			self::$m_instance[$token] = new LeLogger($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled);
+			self::$m_instance[$token] = new LeLogger($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled, $add_local_timestamp);
 		}
 
 		return self::$m_instance[$token];
@@ -87,7 +87,7 @@ class LeLogger
 		self::$m_instance = array();
 	}
 
-	private function __construct($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled)
+	private function __construct($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled, $add_local_timestamp)
 	{
 
 		if ($datahubEnabled===true)
@@ -143,6 +143,9 @@ class LeLogger
 		$this->_host_id = "host_ID=".$host_id;
 		}		
 		
+		
+		// Set timestamp toggle
+		$this->add_timestamp = $add_local_timestamp;
 		
 		$this->persistent = $persistent;
 
@@ -350,7 +353,7 @@ class LeLogger
 		$this->connectIfNotConnected();
 
 		if ($this->severity >= $curr_severity) {
-			$prefix = ''; // $this->_getTime($curr_severity);
+			$prefix = ($this->add_timestamp ? $this->_getTime($curr_severity) . ' - ' : '') . $this->_getLevel($curr_severity) . ' - ';
 
 			$multiline = $this->substituteNewline($line);
 
@@ -403,30 +406,32 @@ public function writeToSocket($line)
 		$this->createSocket();
 	}
 
-	private function _getTime($level)
+	private function _getTime()
 	{
-
-		$time = date(self::$_timestampFormat);
-
+		return date(self::$_timestampFormat);
+	}
+	
+	private function _getLevel($level)
+	{
 		switch ($level) {
 			case LOG_DEBUG:
-				return "$time - DEBUG - ";
+				return "DEBUG";
 			case LOG_INFO:
-				return "$time - INFO - ";
+				return "INFO";
 			case LOG_NOTICE:
-				return "$time - NOTICE - ";
+				return "NOTICE";
 			case LOG_WARNING:
-				return "$time - WARN - ";
+				return "WARN";
 			case LOG_ERR:
-				return "$time - ERROR - ";
+				return "ERROR";
 			case LOG_CRIT:
-				return "$time - CRITICAL - ";
+				return "CRITICAL";
 			case LOG_ALERT:
-				return "$time - ALERT - ";
+				return "ALERT";
 			case LOG_EMERG:
-				return "$time - EMERGENCY - ";
+				return "EMERGENCY";
 			default:
-				return "$time - LOG - ";
+				return "LOG";
 		}
 	}
 }

--- a/LeLogger.php
+++ b/LeLogger.php
@@ -69,8 +69,8 @@ class LeLogger
 	
 	private $errstr;
 
-	{
 	public static function getLogger($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled, $add_local_timestamp)
+	{
 		if ( ! isset(self::$m_instance[$token]))
 		{
 			self::$m_instance[$token] = new LeLogger($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled, $add_local_timestamp);

--- a/logentries.php
+++ b/logentries.php
@@ -53,6 +53,11 @@
 	// if $HOST_ID is empty "", it wil not print to your log events.  This value will only print to your log events if there is a value below as in $HOST_ID="12345".
 	
 	$HOST_ID = "";
+
+	
+	// Add the local server timestamp to each log item
+
+	$ADD_LOCAL_TIMESTAMP = true;
 	
 	
 	
@@ -85,4 +90,4 @@
 	}
 	
 
-	$log = LeLogger::getLogger($LOGENTRIES_TOKEN, $Persistent, $SSL, $Severity, $DATAHUB_ENABLED, $DATAHUB_IP_ADDRESS, $DATAHUB_PORT, $HOST_ID, $HOST_NAME, $HOST_NAME_ENABLED);
+	$log = LeLogger::getLogger($LOGENTRIES_TOKEN, $Persistent, $SSL, $Severity, $DATAHUB_ENABLED, $DATAHUB_IP_ADDRESS, $DATAHUB_PORT, $HOST_ID, $HOST_NAME, $HOST_NAME_ENABLED, $ADD_LOCAL_TIMESTAMP);

--- a/unit_tests/LeLoggerTests.php
+++ b/unit_tests/LeLoggerTests.php
@@ -28,15 +28,15 @@
 
 		public function testAllParameters()
 		{
-			$this->assertInstanceOf('LeLogger', LeLogger::getLogger('token', false, false, LOG_DEBUG, false, "", 10000, "", "", false));
+			$this->assertInstanceOf('LeLogger', LeLogger::getLogger('token', false, false, LOG_DEBUG, false, "", 10000, "", "", false, true));
 
 		}
 
 		public function testMultiplyConnections()
 		{
-			$logFirst = LeLogger::getLogger('token1', false, false, LOG_DEBUG, false, "", 10000, "", "", false);
-			$logSecond = LeLogger::getLogger('token2', false, false, LOG_DEBUG, false, "", 10000, "", "", false);
-			$logThird = LeLogger::getLogger('token3', false, false, LOG_DEBUG, false, "", 10000, "", "", false);
+			$logFirst = LeLogger::getLogger('token1', false, false, LOG_DEBUG, false, "", 10000, "", "", false, true);
+			$logSecond = LeLogger::getLogger('token2', false, false, LOG_DEBUG, false, "", 10000, "", "", false, true);
+			$logThird = LeLogger::getLogger('token3', false, false, LOG_DEBUG, false, "", 10000, "", "", false, true);
 
 			$this->assertNotEquals('token1', $logSecond->getToken());
 			$this->assertNotEquals('token2', $logThird->getToken());
@@ -48,26 +48,26 @@
 
 		public function testIsPersistent()
 		{
-			$log = LeLogger::getLogger('token', false, true, LOG_DEBUG, false, "", 10000, "", "", false);
+			$log = LeLogger::getLogger('token', false, true, LOG_DEBUG, false, "", 10000, "", "", false, true);
 
 			$this->assertFalse($log->isPersistent());
 
 			$this->tearDown();
 
-			$log = LeLogger::getLogger('token', true, true, LOG_DEBUG, false, "", 10000, "", "", false);
+			$log = LeLogger::getLogger('token', true, true, LOG_DEBUG, false, "", 10000, "", "", false, true);
 
 			$this->assertTrue($log->isPersistent());
 		}
 
 		public function testIsTLS()
 		{
-			$log = LeLogger::getLogger('token',false,false, LOG_DEBUG, false, "", 10000, "", "", false);
+			$log = LeLogger::getLogger('token',false,false, LOG_DEBUG, false, "", 10000, "", "", false, true);
 
 			$this->assertFalse($log->isTLS());
 
 			$this->tearDown();
 
-			$log = LeLogger::getLogger('token', true, true, LOG_DEBUG, false, "", 10000, "", "", false);
+			$log = LeLogger::getLogger('token', true, true, LOG_DEBUG, false, "", 10000, "", "", false, true);
 
 			$this->assertTrue($log->isTLS());
 		}
@@ -75,26 +75,26 @@
 		public function testGetPort()
 		{
 
-			$log = LeLogger::getLogger('token', true, false, LOG_DEBUG, false, "",  10000, "", "", false);
+			$log = LeLogger::getLogger('token', true, false, LOG_DEBUG, false, "",  10000, "", "", false, true);
 
 
 			$this->assertEquals(10000, $log->getPort());
 
 			$this->tearDown();
 
-			$log = LeLogger::getLogger('token', true, true, LOG_DEBUG, false, "", 10000, "", "", false);
+			$log = LeLogger::getLogger('token', true, true, LOG_DEBUG, false, "", 10000, "", "", false, true);
 
 			$this->assertEquals(20000, $log->getPort());
 		}
 
 		public function testGetAddress()
 		{
-			$log = LeLogger::getLogger('token', true, false, LOG_DEBUG, false, "", 10000, "", "", false);
+			$log = LeLogger::getLogger('token', true, false, LOG_DEBUG, false, "", 10000, "", "", false, true);
 
 			$this->assertEquals('tcp://api.logentries.com', $log->getAddress());
 
 			$this->tearDown();
-			$log = LeLogger::getLogger('token', true, true, LOG_DEBUG, false, "", 10000, "", "", false);
+			$log = LeLogger::getLogger('token', true, true, LOG_DEBUG, false, "", 10000, "", "", false, true);
 
 
 			$this->assertEquals('tls://api.logentries.com', $log->getAddress());


### PR DESCRIPTION
I may be misunderstanding this and won't be at all offended if you don't merge, but as the Logentries UI shows your local timestamp for the log item, adding the server timestamp is most confusing and causes half the screen to be used up with varying timestamps.