### PR TITLE
Make the port number configurable.

### DIFF
--- a/LeLogger.php
+++ b/LeLogger.php
@@ -35,10 +35,6 @@ class LeLogger
 	const LE_ADDRESS = 'tcp://api.logentries.com';
 	// Logentries server address for receiving logs via TLS
 	const LE_TLS_ADDRESS = 'tls://api.logentries.com';
-	// Logentries server port for receiving logs by token
-	const LE_PORT = 10000;
-	// Logentries server port for receiving logs with TLS by token
-	const LE_TLS_PORT = 20000;
 
 	private $resource = null;
 
@@ -46,7 +42,8 @@ class LeLogger
 	
 	private $_datahubIPAddress = "";
 	private $use_datahub = false;
-	private $_datahubPort = 10000;
+
+	private $port = false;
 
 	private $use_host_name = false;
 	private $_host_name = "";
@@ -69,11 +66,11 @@ class LeLogger
 	
 	private $errstr;
 
-	public static function getLogger($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled, $add_local_timestamp)
+	public static function getLogger($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $port, $host_id, $host_name, $host_name_enabled, $add_local_timestamp)
 	{
 		if ( ! isset(self::$m_instance[$token]))
 		{
-			self::$m_instance[$token] = new LeLogger($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled, $add_local_timestamp);
+			self::$m_instance[$token] = new LeLogger($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $port, $host_id, $host_name, $host_name_enabled, $add_local_timestamp);
 		}
 
 		return self::$m_instance[$token];
@@ -87,7 +84,7 @@ class LeLogger
 		self::$m_instance = array();
 	}
 
-	private function __construct($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $datahubPort, $host_id, $host_name, $host_name_enabled, $add_local_timestamp)
+	private function __construct($token, $persistent, $ssl, $severity, $datahubEnabled, $datahubIPAddress, $port, $host_id, $host_name, $host_name_enabled, $add_local_timestamp)
 	{
 
 		if ($datahubEnabled===true)
@@ -99,7 +96,6 @@ class LeLogger
 			// set Datahub variable values			
 			$this->_datahubIPAddress = $datahubIPAddress;
 			$this->use_datahub = $datahubEnabled;
-			$this->_datahubPort = $datahubPort;	
 		
 		
 			// if datahub is being used the logToken should be set to null
@@ -157,6 +153,8 @@ class LeLogger
 		$this->severity = $severity;
 
 		$this->connectionTimeout = (float) ini_get('default_socket_timeout');
+
+		$this->port = $port;
 	}
 
 
@@ -206,18 +204,7 @@ class LeLogger
 
 	public function getPort()
 	{
-		if ($this->isTLS())
-		{
-			return self::LE_TLS_PORT;
-		}
-		elseif ($this->isDatahub() )
-		{
-		 	return $this->_datahubPort;
-		}
-		else
-		{
-			return self::LE_PORT;
-		}
+		return $this->port;
 	}
 	
 	


### PR DESCRIPTION
I need to do this since some hosts block communication on non standard ports, e.g. 10000. But Logentries supports various ports, so this is easily avoidable by making the port configurable.

- Removed the predefined constants.
- Removed property for DataHub port.
- Removed datahubPort argument from constructor.
- Added port argument to constructor.
- Return port property when calling getPort().

I'm not 100% sure about how the DataHub integration works, but this approach aims at keeping a single port for the entire instance by making it configurable via the constructor.